### PR TITLE
Implement Read trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ Rust implementation of the Apple Data Compression scheme used in DMG images.
 edition = "2018"
 
 [dependencies]
-bincode = "1.3.1"
+byteorder = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["compression"]
 description = """
 Rust implementation of the Apple Data Compression scheme used in DMG images.
 """
+edition = "2018"
 
 [dependencies]
 bincode = "1.3.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,11 +6,12 @@
 //!
 //! ```
 //! use adc::AdcDecoder;
+//! use std::io::Read;
 //!
 //! let input: &[u8] = &[0x83, 0xfe, 0xed, 0xfa, 0xce, 0x00, 0x00, 0x40, 0x00, 0x06];
 //! let mut d = AdcDecoder::new(input);
 //! let mut data = vec![0; 11];
-//! let bytes_out = match d.decompress_into(&mut data[..]) {
+//! let bytes_out = match d.read_exact(&mut data) {
 //!     Ok(val) => val,
 //!     Err(err) => panic!("error: {:?}", err),
 //! };
@@ -18,7 +19,12 @@
 //! ````
 
 use byteorder::{ReadBytesExt, BE};
-use std::io::prelude::*;
+use std::{
+    cmp,
+    collections::VecDeque,
+    io::{self, prelude::*},
+    u16,
+};
 
 #[derive(PartialEq, Debug)]
 enum AdcChunkType {
@@ -30,47 +36,67 @@ enum AdcChunkType {
 #[derive(PartialEq, Debug)]
 struct AdcChunk {
     r#type: AdcChunkType,
-    size: usize,
-    offset: usize,
+    size: u8,
+    offset: u16,
+}
+
+/// Window into the decompressed output.
+///
+/// Used to get output bytes for the run-length chunks.
+/// Implemented as a non-growable ring buffer.
+struct Window(VecDeque<u8>);
+
+impl Window {
+    // The windows needs to fit `max offset` bytes.
+    const SIZE: usize = u16::MAX as usize;
+
+    fn new() -> Self {
+        Self(VecDeque::with_capacity(Self::SIZE))
+    }
+
+    fn extend(&mut self, bytes: &[u8]) {
+        // remove from the back to ensure we have enough room
+        let max_size = Self::SIZE - bytes.len();
+        self.0.truncate(max_size);
+
+        // push new bytes to the front
+        for &byte in bytes {
+            self.0.push_front(byte);
+        }
+    }
+
+    fn get(&self, idx: u16) -> Option<u8> {
+        self.0.get(idx as usize).copied()
+    }
 }
 
 /// Main type for decompressing ADC data.
 pub struct AdcDecoder<R> {
     input: R,
-}
-
-/// This type represents all possible errors that can occur when decompressing data.
-#[derive(Debug, PartialEq)]
-pub enum AdcError {
-    /// The was an IO error while reading or writing.
-    Io(String),
-    /// The buffer was not large enough for the decompressed data.
-    BufferTooSmall,
-    /// The input is invalid.
-    InvalidInput,
-}
-
-impl std::fmt::Display for AdcError {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match *self {
-            AdcError::Io(ref err) => write!(fmt, "{}", err),
-            AdcError::BufferTooSmall => write!(fmt, "output buffer too small"),
-            AdcError::InvalidInput => write!(fmt, "invalid input data"),
-        }
-    }
+    current_chunk: Option<AdcChunk>,
+    window: Window,
 }
 
 impl<R: Read> AdcDecoder<R> {
     /// Create a new decoder instance from a readable input
     pub fn new(input: R) -> AdcDecoder<R> {
-        AdcDecoder { input }
+        AdcDecoder {
+            input,
+            current_chunk: None,
+            window: Window::new(),
+        }
     }
 
-    fn get_next_chunk(&mut self) -> Result<Option<AdcChunk>, AdcError> {
+    /// Update `self.current_chunk` with the next chunk.
+    fn next_chunk(&mut self) -> io::Result<()> {
         let byte = match self.input.read_u8() {
-            Err(_) => return Ok(None), // reached eof
             Ok(val) => val,
+            Err(_) => {
+                self.current_chunk = None;
+                return Ok(());
+            }
         };
+
         let chunk_type = if (byte & 0x80) != 0 {
             AdcChunkType::Plain
         } else if (byte & 0x40) != 0 {
@@ -82,72 +108,77 @@ impl<R: Read> AdcDecoder<R> {
         let chunk = match chunk_type {
             AdcChunkType::Plain => AdcChunk {
                 r#type: chunk_type,
-                size: ((byte & 0x7f) + 1) as usize,
+                size: (byte & 0x7f) + 1,
                 offset: 0,
             },
             AdcChunkType::TwoByte => {
-                let byte2 = match self.input.read_u8() {
-                    Err(err) => return Err(AdcError::Io(format!("{}", err))),
-                    Ok(val) => val,
-                };
+                let byte2 = self.input.read_u8()?;
                 AdcChunk {
                     r#type: chunk_type,
-                    size: (((byte & 0x3f) >> 2) + 3) as usize,
-                    offset: (((byte as usize) & 0x3) << 8) + byte2 as usize,
+                    size: ((byte & 0x3f) >> 2) + 3,
+                    offset: ((u16::from(byte) & 0x3) << 8) + u16::from(byte2),
                 }
             }
             AdcChunkType::ThreeByte => {
-                let offset = match self.input.read_u16::<BE>() {
-                    Err(err) => return Err(AdcError::Io(format!("{}", err))),
-                    Ok(val) => val,
-                };
+                let offset = self.input.read_u16::<BE>()?;
                 AdcChunk {
                     r#type: chunk_type,
-                    size: ((byte & 0x3f) + 4) as usize,
-                    offset: offset as usize,
+                    size: (byte & 0x3f) + 4,
+                    offset,
                 }
             }
         };
 
-        Ok(Some(chunk))
+        self.current_chunk = Some(chunk);
+        Ok(())
     }
 
-    /// Decompress input into byte array
-    pub fn decompress_into(&mut self, output: &mut [u8]) -> Result<usize, AdcError> {
-        // ADC is basic run length compression. AdcChunkType::Plain chunk contains data, the other two
-        // specify the run length and an optional offset.
-        let mut cur_pos = 0;
-        loop {
-            // get next chunk or return if None
-            let chunk = match self.get_next_chunk()? {
-                None => return Ok(cur_pos),
-                Some(val) => val,
-            };
+    fn read_from_chunk(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let chunk = match self.current_chunk {
+            Some(ref mut c) => c,
+            None => return Ok(0),
+        };
 
-            if cur_pos + chunk.size > output.len() {
-                return Err(AdcError::BufferTooSmall);
-            }
+        let read_len = cmp::min(chunk.size as usize, buf.len());
+        let buf = &mut buf[..read_len];
 
-            if chunk.r#type == AdcChunkType::Plain {
-                // copy from input to output
-                if let Err(err) = self
-                    .input
-                    .read_exact(&mut output[cur_pos..cur_pos + chunk.size])
-                {
-                    return Err(AdcError::Io(format!("{}", err)));
-                }
-                cur_pos += chunk.size;
-            } else {
-                if cur_pos == 0 || chunk.offset > cur_pos - 1 {
-                    return Err(AdcError::InvalidInput);
-                }
-                // copy repeated bytes
-                for _ in 0..chunk.size {
-                    output[cur_pos] = output[cur_pos - chunk.offset - 1];
-                    cur_pos += 1;
-                }
+        if chunk.r#type == AdcChunkType::Plain {
+            self.input.read_exact(buf)?;
+            self.window.extend(buf);
+        } else {
+            // read run of bytes from the output window
+            for elem in buf.iter_mut() {
+                let byte = match self.window.get(chunk.offset) {
+                    Some(b) => b,
+                    None => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "invalid chunk offset",
+                        ))
+                    }
+                };
+
+                *elem = byte;
+                self.window.extend(&[byte]);
             }
         }
+
+        chunk.size -= read_len as u8;
+        if chunk.size == 0 {
+            self.current_chunk = None;
+        }
+
+        Ok(read_len)
+    }
+}
+
+impl<R: Read> Read for AdcDecoder<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.current_chunk.is_none() {
+            self.next_chunk()?;
+        }
+
+        self.read_from_chunk(buf)
     }
 }
 
@@ -161,10 +192,11 @@ mod tests {
         let output: &[u8] = &[
             0xfe, 0xed, 0xfa, 0xce, 0xce, 0xce, 0xce, 0xfe, 0xed, 0xfa, 0xce,
         ];
+
         let mut d = AdcDecoder::new(input);
         let mut data = vec![0; output.len()];
-        let bytes_out = d.decompress_into(&mut data[..]).unwrap();
-        assert_eq!(bytes_out, output.len());
+        d.read_exact(&mut data).unwrap();
+
         assert_eq!(output[..], data[..]);
     }
 
@@ -172,43 +204,47 @@ mod tests {
     fn invalid_input() {
         // offset is too big
         let input: &[u8] = &[0x83, 0xfe, 0xed, 0xfa, 0xce, 0x00, 0xff];
+
         let mut d = AdcDecoder::new(input);
         let mut data = vec![0; 10];
-        let bytes_out = d.decompress_into(&mut data[..]);
-        assert_eq!(bytes_out, Err(AdcError::InvalidInput));
+        let err = d.read_exact(&mut data).unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 
     #[test]
     fn invalid_input2() {
         // run-length chunk at position 0
         let input: &[u8] = &[0x00, 0x00];
+
         let mut d = AdcDecoder::new(input);
         let mut data = vec![0; 10];
-        let bytes_out = d.decompress_into(&mut data[..]);
-        assert_eq!(bytes_out, Err(AdcError::InvalidInput));
+        let err = d.read_exact(&mut data).unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 
     #[test]
     fn invalid_input3() {
         // missing 2nd byte
         let input: &[u8] = &[0x83, 0xfe, 0xed, 0xfa, 0xce, 0x00];
+
         let mut d = AdcDecoder::new(input);
         let mut data = vec![0; 10];
-        let bytes_out = d.decompress_into(&mut data[..]);
-        assert_eq!(
-            bytes_out,
-            Err(AdcError::Io("failed to fill whole buffer".to_string()))
-        );
+        let err = d.read_exact(&mut data).unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
     }
 
     #[test]
     fn empty() {
         let input: &[u8] = &[];
         let output: &[u8] = &[];
+
         let mut d = AdcDecoder::new(input);
         let mut data = vec![0; output.len()];
-        let bytes_out = d.decompress_into(&mut data[..]).unwrap();
-        assert_eq!(bytes_out, output.len());
+        d.read_exact(&mut data).unwrap();
+
         assert_eq!(output[..], data[..]);
     }
 }


### PR DESCRIPTION
This PR ports the AdcDecoder from the custom `decompress_into` method to implementing the `Read` trait instead.

Also includes various minor improvements, such as updating to the 2018 edition and replacing bincode with the byteorder crate.

Required for citruz/dmgwiz#10.